### PR TITLE
Implement keydown for arrow keys and card movement

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,12 +10,11 @@ const config: PlaywrightTestConfig = {
 	fullyParallel: true,
 	testMatch: /(.+\.)?(test|spec)\.[jt]s/,
 	projects: [
-		/*
 		{
 			name: 'chromium',
 			use: { ...devices['Desktop Chrome'], hasTouch: true },
+			testMatch: /keyboard/
 		},
-		*/
 		{
 			name: 'Mobile Chrome',
 			use: { ...devices['Pixel 7'], hasTouch: true },

--- a/src/lib/components/cards/PlayingCardWidget.svelte
+++ b/src/lib/components/cards/PlayingCardWidget.svelte
@@ -148,6 +148,24 @@
     }
   }
 
+  // Using keyDown because arrow keys only fire on keydown
+  function handleKeyDown(event: KeyboardEvent) {
+    switch (event.key) {
+      case 'ArrowUp':
+        handleClick();
+      break;
+      case 'ArrowDown':
+        handlePutBack();
+      break;
+      case 'ArrowLeft':
+        handlePutBack();
+      break;
+      case 'ArrowRight':
+        handleClick();
+      break;
+    }
+  }
+
   onMount(async () => {
     if ( id.includes('discarded') ) return;
     let card = document.getElementById(`${id}`);
@@ -175,6 +193,7 @@
   aria-disabled={disabled}
   disabled={disabled}
   use:setFocus
+  on:keydown={handleKeyDown}
 >
   <section class="rank-and-suit">
 

--- a/tests/keyboard.test.ts
+++ b/tests/keyboard.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+	await page.goto('/');
+	await page.waitForLoadState('domcontentloaded');
+	await page.getByRole('link', { name: 'Play' }).click();
+	await page.waitForLoadState('domcontentloaded');
+	await page.getByRole('link', { name: 'Cards' }).click();
+	await page.waitForLoadState('domcontentloaded');
+	await page.getByRole('button', { name: 'Start' }).click();
+	await page.waitForLoadState('domcontentloaded');
+});
+
+test.describe('Space', () => {
+	test('expect discard', async ({ page }) => {
+		const discardedCardsListItemBefore = await page.getByTestId('discarded-card-listitem').all();
+		expect(discardedCardsListItemBefore.length).toBe(0);
+		await page.keyboard.press('Space');
+		await page.waitForLoadState('domcontentloaded');
+		const discardedCardsListItemAfter = await page.getByTestId('discarded-card-listitem').all();
+		expect(discardedCardsListItemAfter.length).toBe(1);
+	});
+
+});
+
+test.describe('Enter', () => {
+	test('expect discard', async ({ page }) => {
+		const discardedCardsListItemBefore = await page.getByTestId('discarded-card-listitem').all();
+		expect(discardedCardsListItemBefore.length).toBe(0);
+		await page.keyboard.press('Enter');
+		await page.waitForLoadState('domcontentloaded');
+		const discardedCardsListItemAfter = await page.getByTestId('discarded-card-listitem').all();
+		expect(discardedCardsListItemAfter.length).toBe(1);
+	});
+
+});
+
+test.describe('Arrow Keys', () => {
+	test('UP expect discard', async ({ page }) => {
+		const discardedCardsListItemBefore = await page.getByTestId('discarded-card-listitem').all();
+		expect(discardedCardsListItemBefore.length).toBe(0);
+		await page.keyboard.press('ArrowUp');
+		await page.waitForLoadState('domcontentloaded');
+		const discardedCardsListItemAfter = await page.getByTestId('discarded-card-listitem').all();
+		expect(discardedCardsListItemAfter.length).toBe(1);
+	});
+
+	test('DOWN expect no discard', async ({ page }) => {
+		const discardedCardsListItemBefore = await page.getByTestId('discarded-card-listitem').all();
+		expect(discardedCardsListItemBefore.length).toBe(0);
+		await page.keyboard.press('ArrowDown');
+		await page.waitForLoadState('domcontentloaded');
+		const discardedCardsListItemAfter = await page.getByTestId('discarded-card-listitem').all();
+		expect(discardedCardsListItemAfter.length).toBe(0);
+	});
+
+	test('LEFT expect no discard', async ({ page }) => {
+		const discardedCardsListItemBefore = await page.getByTestId('discarded-card-listitem').all();
+		expect(discardedCardsListItemBefore.length).toBe(0);
+		await page.keyboard.press('ArrowLeft');
+		await page.waitForLoadState('domcontentloaded');
+		const discardedCardsListItemAfter = await page.getByTestId('discarded-card-listitem').all();
+		expect(discardedCardsListItemAfter.length).toBe(0);
+	});
+
+	test('RIGHT expect discard', async ({ page }) => {
+		const discardedCardsListItemBefore = await page.getByTestId('discarded-card-listitem').all();
+		expect(discardedCardsListItemBefore.length).toBe(0);
+		await page.keyboard.press('ArrowRight');
+		await page.waitForLoadState('domcontentloaded');
+		const discardedCardsListItemAfter = await page.getByTestId('discarded-card-listitem').all();
+		expect(discardedCardsListItemAfter.length).toBe(1);
+	});
+
+});


### PR DESCRIPTION
After writing on LinkedIn about the keyboard friendliness of the app, I realized that there was no way to use the keyboard to put cards back in the deck.

- wrote tests first
- used switch case to handle movement of the cards
- found out that arrow keys do not fire on keypress but on keydown
- re-wrote tests because they failed
 - rather I failed to write them correctly in the first place