### PR TITLE
Fix bug in stopwatch start and continue

### DIFF
--- a/src/lib/components/cards/PlayingCardWidget.svelte
+++ b/src/lib/components/cards/PlayingCardWidget.svelte
@@ -129,6 +129,7 @@
 
   function continueStopwatch(): void {
     if ( $workoutStopwatch.running ) return;
+    if ( $suitExercises.some(exercisesHaveNotBeenChosen) ) return;
     workoutStopwatch.continue();
   }
 

--- a/src/lib/components/cards/StartButton.svelte
+++ b/src/lib/components/cards/StartButton.svelte
@@ -15,9 +15,11 @@
     theDeckOfCards.pluck($randomCardIndex);
     randomCard && theCurrentCard.data(randomCard);
 
-    if ($suitExercises.some(exercisesHaveNotBeenChosen)) return;
-
-    workoutStopwatch.start();
+    if ($suitExercises.some(exercisesHaveNotBeenChosen)) {
+      return;
+    } else {
+      workoutStopwatch.start();
+    }
   }
 
 </script>


### PR DESCRIPTION
1. Makes sure that when the start button is clicked, it only starts the stopwatch if exercises have been chosen.
2. Main problem was card movement called stopwatch continue. Solution: return the function early if exercises have not been chosen