### PR TITLE
Fix stopwatch bug after nav back to Exercise Page

### DIFF
--- a/src/lib/components/exercises/ExerciseSelectionCompleteButton.svelte
+++ b/src/lib/components/exercises/ExerciseSelectionCompleteButton.svelte
@@ -3,7 +3,8 @@
     suitExercises,
     theDeckOfCards,
     discardedCards,
-	theCurrentCard,
+    theCurrentCard,
+    workoutStopwatch,
   } from "../../../store";
   import { goto } from "$app/navigation";
   import { setFocus } from '$lib/utils';
@@ -11,6 +12,9 @@
   import type { TSuit } from "../../../types/suit";
 
   async function handleClick() {
+    if ( $workoutStopwatch.running ) {
+      workoutStopwatch.reset();
+    }
     theDeckOfCards.setExercises($suitExercises);
     discardedCards.reset();
     theCurrentCard.reset();

--- a/src/lib/components/exercises/ExerciseSelectionCompleteButton.svelte
+++ b/src/lib/components/exercises/ExerciseSelectionCompleteButton.svelte
@@ -12,7 +12,7 @@
   import type { TSuit } from "../../../types/suit";
 
   async function handleClick() {
-    if ( $workoutStopwatch.running ) {
+    if ( $workoutStopwatch.elapsedTime > 0) {
       workoutStopwatch.reset();
     }
     theDeckOfCards.setExercises($suitExercises);


### PR DESCRIPTION
Noticed that there was a bug with the timer.

Before:
- After hitting start, the timer begins.
- When a user navigates back to the exercises page, "Let's Go" button is still enabled, and when clicked, it would have no effect on the timer.

After:
- clicking the "Let's Go" button resets the stopwatch, but only if it is running. I did not account for pause. BRB