### PR TITLE
feat(cards): adjust layout

### DIFF
--- a/src/routes/cards/+layout.svelte
+++ b/src/routes/cards/+layout.svelte
@@ -19,7 +19,8 @@
 <style>
 	main {
 		height: 100%;
-		width: 100%;
+		max-width: 88.25rem;
+		margin: auto;
 		display: grid;
 		grid-template-columns: 1fr;
 		grid-template-rows: min-content 181.8px 1fr min-content;


### PR DESCRIPTION
Give cards layout a max-width so discarded area is not larger than the width of all discarded cards on larger screens.