### PR TITLE
chore(tests): update tests for setup/library route renames

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"svelte-french-toast": "^1.2.0"
 			},
 			"devDependencies": {
-				"@playwright/test": "^1.28.1",
+				"@playwright/test": "^1.60.0",
 				"@sveltejs/adapter-vercel": "^6.3.3",
 				"@sveltejs/kit": "^2.61.1",
 				"@sveltejs/vite-plugin-svelte": "^3.0.0",
@@ -733,18 +733,19 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.41.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.1.tgz",
-			"integrity": "sha512-9g8EWTjiQ9yFBXc6HjCWe41msLpxEX0KhmfmPl9RPLJdfzL4F0lg2BdJ91O9azFdl11y1pmpwdjBiSxvqc+btw==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.41.1"
+				"playwright": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@polka/url": {
@@ -3881,33 +3882,35 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.41.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.1.tgz",
-			"integrity": "sha512-gdZAWG97oUnbBdRL3GuBvX3nDDmUOuqzV/D24dytqlKt+eI5KbwusluZRGljx1YoJKZ2NRPaeWiFTeGZO7SosQ==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.41.1"
+				"playwright-core": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			},
 			"optionalDependencies": {
 				"fsevents": "2.3.2"
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.41.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.1.tgz",
-			"integrity": "sha512-/KPO5DzXSMlxSX77wy+HihKGOunh3hqndhqeo/nMxfigiKzogn8kfL0ZBDu0L1RKgan5XHCPmn6zXd2NUJgjhg==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			}
 		},
 		"node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"test:unit": "vitest"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.28.1",
+		"@playwright/test": "^1.60.0",
 		"@sveltejs/adapter-vercel": "^6.3.3",
 		"@sveltejs/kit": "^2.61.1",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",

--- a/src/lib/components/index/ExerciseIndexCard.svelte
+++ b/src/lib/components/index/ExerciseIndexCard.svelte
@@ -17,7 +17,7 @@
 					<h1 class="oswald-header header">{exerciseName}</h1>
 				{:else}
 					<h1 class="oswald-header header">
-						<a href={`/index/${hrefExerciseName}`}>
+						<a href={`/library/${hrefExerciseName}`}>
 							{exerciseName}
 						</a>
 					</h1>

--- a/tests/activities.test.ts
+++ b/tests/activities.test.ts
@@ -2,6 +2,7 @@ import { exerciseEmoji, homeEmoji, repeatEmoji, wasteBasketEmoji } from '../src/
 import { expect, test } from '@playwright/test';
 import { setLocalStorageWorkouts } from './helperFunctions/localStorage';
 import { fakeWorkoutData } from './fakeWorkoutData';
+import { links } from '../src/lib/strings/forHomepage';
 
 const workoutsForLocalStorage = JSON.stringify(fakeWorkoutData);
 const singleWorkoutForLocalStorage = JSON.stringify([fakeWorkoutData[0]]);
@@ -59,7 +60,7 @@ test.describe('one saved workout', () => {
 
 		test('expect exercises to be reset', async ({ page }) => {
 			await expect(page.getByRole('heading', { name: 'SUIT YOURSELF' })).toBeVisible();
-			await page.getByRole('link', { name: 'EXERCISES' }).click();
+			await page.getByRole('link', { name: links.exercises.toUpperCase() }).click();
 			await page.waitForLoadState('domcontentloaded');
 			await expect(page.locator('.example-workout-section')).toBeVisible();
 		});
@@ -127,7 +128,7 @@ test.describe('ACTIVITIES page', () => {
 				const cardsLink = page.getByRole('link', { name: exerciseEmoji });
 				await cardsLink.click();
 				await page.waitForLoadState('domcontentloaded');
-				await expect(page.getByRole('heading', { name: 'EXERCISES', level: 1 })).toBeVisible();
+				await expect(page.getByRole('heading', { name: links.exercises.toUpperCase(), level: 1 })).toBeVisible();
 			});
 		});
 	});

--- a/tests/homePage.test.ts
+++ b/tests/homePage.test.ts
@@ -18,7 +18,7 @@ test.describe('hompage links are active and enabled', () => {
 		await expect(aboutLink).toBeEnabled();
 	});
 
-	test('Exercises', async ({ page }) => {
+	test('Setup', async ({ page }) => {
 		const exercisesLink = page.getByRole('link', { name: links.exercises.toUpperCase() });
 		await expect(exercisesLink).toBeVisible();
 		await expect(exercisesLink).toBeEnabled();

--- a/tests/library/checkBoxes.test.ts
+++ b/tests/library/checkBoxes.test.ts
@@ -1,11 +1,14 @@
 import { expect, test } from '@playwright/test';
 import { EExerciseCategories } from '../../src/enums/exerciseCategories';
 import { EExerciseNames } from '../../src/enums/exerciseNames';
+import { links } from '../../src/lib/strings/forHomepage';
+
+const libraryLinkName = links.index.toUpperCase();
 
 test.beforeEach(async ({ page }) => {
 	await page.goto('/');
 	await page.waitForLoadState('domcontentloaded');
-	await page.getByRole('link', { name: 'INDEX' }).click();
+	await page.getByRole('link', { name: libraryLinkName }).click();
 	await page.waitForLoadState('domcontentloaded');
 	const summary = page.locator('summary');
 	await summary.click();
@@ -39,7 +42,7 @@ test.describe('checkboxes', () => {
 			const yogaIndexExerciseCardsBeforeNavigation = await page.getByRole('list').allInnerTexts();
 			await page.goBack({ waitUntil: 'domcontentloaded' });
 
-			await page.getByRole('link', { name: 'INDEX' }).click();
+			await page.getByRole('link', { name: libraryLinkName }).click();
 			await page.waitForLoadState('domcontentloaded');
 
 			const yogaCheckboxAfterNavigation = page.getByLabel(EExerciseCategories.YOGA);

--- a/tests/library/demos.test.ts
+++ b/tests/library/demos.test.ts
@@ -1,11 +1,12 @@
 import { exercises } from '../../src/lib/exercisesDB';
 import { EExerciseNames } from '../../src/enums/exerciseNames';
 import { expect, test } from '@playwright/test';
+import { links } from '../../src/lib/strings/forHomepage';
 
 test.beforeEach(async ({ page }) => {
 	await page.goto('/');
 	await page.waitForLoadState('domcontentloaded');
-	await page.getByRole('link', { name: 'INDEX' }).click();
+	await page.getByRole('link', { name: links.index.toUpperCase() }).click();
 	await page.waitForLoadState('domcontentloaded');
 });
 

--- a/tests/library/page.test.ts
+++ b/tests/library/page.test.ts
@@ -1,16 +1,19 @@
 import { expect, test } from '@playwright/test';
 import { exerciseEmoji, homeEmoji } from '../../src/lib/emojis';
+import { links } from '../../src/lib/strings/forHomepage';
+
+const libraryLinkName = links.index.toUpperCase();
 
 test.beforeEach(async ({ page }) => {
 	await page.goto('/');
 	await page.waitForLoadState('domcontentloaded');
-	await page.getByRole('link', { name: 'INDEX' }).click();
+	await page.getByRole('link', { name: libraryLinkName }).click();
 	await page.waitForLoadState('domcontentloaded');
 });
 
-test.describe('Index page elements', () => {
+test.describe('Library page elements', () => {
 	test('expect correct heading', async ({ page }) => {
-		await expect(page.getByRole('heading', { name: 'INDEX', level: 1 })).toBeVisible();
+		await expect(page.getByRole('heading', { name: libraryLinkName, level: 1 })).toBeVisible();
 	});
 
 	test('expect search input', async ({ page }) => {

--- a/tests/library/search.test.ts
+++ b/tests/library/search.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@playwright/test';
 import { EExerciseNames } from '../../src/enums/exerciseNames';
+import { links } from '../../src/lib/strings/forHomepage';
 
 test.beforeEach(async ({ page }) => {
 	await page.goto('/');
 	await page.waitForLoadState('domcontentloaded');
-	await page.getByRole('link', { name: 'INDEX' }).click();
+	await page.getByRole('link', { name: links.index.toUpperCase() }).click();
 	await page.waitForLoadState('domcontentloaded');
 });
 

--- a/tests/saveWorkout.test.ts
+++ b/tests/saveWorkout.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 import { EExerciseNames } from '../src/enums/exerciseNames';
 import { ESuit } from '../src/enums/suit';
 import { getLocalStorageWorkouts } from './helperFunctions/localStorage';
+import { links } from '../src/lib/strings/forHomepage';
 
 const [exercise1, exercise2, exercise3, exercise4] = Object.keys(EExerciseNames);
 
@@ -12,7 +13,7 @@ test.describe('persist workouts to local storage', () => {
 		test.setTimeout(51 * 1000);
 		await page.goto('/');
 		await page.waitForLoadState('domcontentloaded');
-		await page.getByRole('link', { name: 'Exercises' }).click();
+		await page.getByRole('link', { name: links.exercises.toUpperCase() }).click();
 		await page.waitForLoadState('domcontentloaded');
 
 		const clubsSelect = page.locator(`#${clubs}-exercise-select`);

--- a/tests/selectingExercises.test.ts
+++ b/tests/selectingExercises.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { EExerciseNames } from '../src/enums/exerciseNames';
 import { ESuit } from '../src/enums/suit';
+import { links } from '../src/lib/strings/forHomepage';
 
 const [exercise1, exercise2, exercise3, exercise4] = Object.keys(EExerciseNames);
 const [clubs, diamonds, hearts, spades] = Object.keys(ESuit);
@@ -8,7 +9,7 @@ const [clubs, diamonds, hearts, spades] = Object.keys(ESuit);
 test.beforeEach(async ({ page }) => {
 	await page.goto('/');
 	await page.waitForLoadState('domcontentloaded');
-	await page.getByRole('link', { name: 'Exercises' }).click();
+	await page.getByRole('link', { name: links.exercises.toUpperCase() }).click();
 	await page.waitForLoadState('domcontentloaded');
 
 	await page.locator(`#${clubs}-exercise-select`).selectOption(exercise1);

--- a/tests/setupPage.test.ts
+++ b/tests/setupPage.test.ts
@@ -2,18 +2,20 @@ import { expect, test } from '@playwright/test';
 import { ESuit } from '../src/enums/suit';
 import { EExerciseNames } from '../src/enums/exerciseNames';
 import { homeEmoji, cardEmoji } from '../src/lib/emojis';
+import { links } from '../src/lib/strings/forHomepage';
 
 const [clubs, diamonds, hearts, spades] = Object.keys(ESuit);
 const [exercise1, exercise2, exercise3, exercise4] = Object.keys(EExerciseNames);
+const setupLinkName = links.exercises.toUpperCase();
 
 test.beforeEach(async ({ page }) => {
 	await page.goto('/');
 	await page.waitForLoadState('domcontentloaded');
-	await page.getByRole('link', { name: 'Exercises' }).click();
+	await page.getByRole('link', { name: setupLinkName }).click();
 });
 
 test('exercise page has expected h1', async ({ page }) => {
-	await expect(page.getByRole('heading', { name: 'Exercises', level: 1 })).toBeVisible();
+	await expect(page.getByRole('heading', { name: setupLinkName, level: 1 })).toBeVisible();
 });
 
 test.describe('exercise page has correct links', () => {

--- a/tests/stopwatch.test.ts
+++ b/tests/stopwatch.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 import { ESuit } from '../src/enums/suit';
 import { EExerciseNames } from '../src/enums/exerciseNames';
 import { EStopwatchButtonString } from '../src/enums/stopwatchButtonString';
+import { links } from '../src/lib/strings/forHomepage';
 
 const [clubs, diamonds, hearts, spades] = Object.keys(ESuit);
 
@@ -11,7 +12,7 @@ test.describe('stopwatch', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
 		await page.waitForLoadState('domcontentloaded');
-		await page.getByRole('link', { name: 'EXERCISES' }).click();
+		await page.getByRole('link', { name: links.exercises.toUpperCase() }).click();
 		await page.waitForLoadState('domcontentloaded');
 
 		await page.locator(`#${clubs}-exercise-select`).selectOption(exercise1);

--- a/tests/workoutFlow.test.ts
+++ b/tests/workoutFlow.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { EExerciseNames } from '../src/enums/exerciseNames';
 import { ESuit } from '../src/enums/suit';
+import { links } from '../src/lib/strings/forHomepage';
 
 const [exercise1, exercise2, exercise3, exercise4] = Object.keys(EExerciseNames);
 
@@ -9,7 +10,7 @@ const [clubs, diamonds, hearts, spades] = Object.keys(ESuit);
 test.beforeEach(async ({ page }) => {
 	await page.goto('/');
 	await page.waitForLoadState('domcontentloaded');
-	await page.getByRole('link', { name: 'Exercises' }).click();
+	await page.getByRole('link', { name: links.exercises.toUpperCase() }).click();
 	await page.waitForLoadState('domcontentloaded');
 
 	await page.locator(`#${clubs}-exercise-select`).selectOption(exercise1);
@@ -26,7 +27,7 @@ test.describe('initial visibilities', () => {
 		await expect(page.getByRole('heading', { name: 'SUIT YOURSELF', level: 1 })).toBeVisible();
 	});
 
-	test('has expected "HOME" and "EXERCISES" links', async ({ page }) => {
+	test('has expected "HOME" and "SETUP" links', async ({ page }) => {
 		const homeLink = page.getByRole('link', { name: '🏠' });
 		const exercisesLink = page.getByRole('link', { name: '🤸' });
 		await expect(homeLink).toBeVisible();


### PR DESCRIPTION
- Rename tests/exercisesPage.test.ts → tests/setupPage.test.ts
- Rename tests/index/ → tests/library/ (all 4 files)
- Replace hardcoded route strings ('EXERCISES', 'INDEX') with dynamic values from forHomepage.ts links object so future renames propagate automatically
- Fix ExerciseIndexCard.svelte: exercise detail hrefs now use /library/ instead of /index/
- Update @playwright/test 1.41.1 → 1.60.0 for Node.js 24 compatibility