### PR TITLE
fix(layout): prevent CardsInfoWidget from being pushed off-screen on …

### DIFF
--- a/src/routes/cards/+page.svelte
+++ b/src/routes/cards/+page.svelte
@@ -135,11 +135,20 @@
 		align-items: center;
 	}
 	.current-card-section {
+		position: relative;
 		height: 100%;
+		justify-self: stretch;
 		display: grid;
 		grid-template-columns: 1fr;
 		grid-template-rows: auto-fill;
 		justify-items: center;
+		align-items: center;
+	}
+	.card-outer-container {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		justify-content: center;
 		align-items: center;
 	}
 	.no-cards-showing {


### PR DESCRIPTION
…rapid input

Svelte's crossfade out:send transition keeps outgoing card elements in normal document flow for ~240ms. Rapid spacebar/enter/swipe actions cause multiple transitioning cards to stack in .current-card-section, expanding the 1fr grid row and pushing CardsInfoWidget below the viewport.

Fix: position .card-outer-container absolutely within .current-card-section so transitioning cards are removed from layout flow and cannot cause the section to expand. Add justify-self: stretch to ensure the section fills its 161.8px grid column (overriding the parent justify-items: center that would otherwise collapse it to 0 width with no in-flow content).